### PR TITLE
revise design on bottom lectures and add building's name

### DIFF
--- a/screens/classDetails.js
+++ b/screens/classDetails.js
@@ -2,17 +2,37 @@ import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
+// 教室名と棟名が空白の場合の処理
+function changeName(roomeName, buildingName,) {
+  if (roomeName == '' || buildingName == '') {
+    return '未定またはオンライン講義です';
+  }
+  else if (buildingName != '' && roomeName == '') {
+    return buildingName;
+  }
+  else if (buildingName == '' && roomeName != '') {
+    return roomeName;
+  }
+  else if (buildingName != '' && roomeName != '') {
+    return buildingName + '\n' + roomeName;
+  }
+};
+
 //授業詳細画面
 export default function classDetails({ navigation, lectureInfo }) {
   const { 科目 } = lectureInfo.params;
   const { 担当 } = lectureInfo.params;
   const { 教室名 } = lectureInfo.params;
+  const { 棟名 } = lectureInfo.params;
+  const { 棟 } = lectureInfo.params;
   const { 曜日時限 } = lectureInfo.params;
-  let balnkClass = null;
-  if (教室名 == '') {
-    balnkClass = '未定またはオンライン講義です';
-  } else {
-    balnkClass = 教室名;
+  let displayedRoomName = '';
+
+  if (棟名 == undefined && 棟 != undefined) {
+    displayedRoomName = changeName(教室名, 棟);
+  }
+  else if (棟名 != undefined && 棟 == undefined) {
+    displayedRoomName = changeName(教室名, 棟名);
   }
 
   //全角・半角空白除去処理
@@ -31,7 +51,7 @@ export default function classDetails({ navigation, lectureInfo }) {
     classDayTime = dayTime.split('・')
   }
 
-  //曜日時限 表示
+  //曜日時限 表示 （↓の処理はもっと簡潔にしてください）
   let showDayTime = null;
   const DaytimeLength = classDayTime.length;
   if (曜日時限 == '他') {
@@ -87,8 +107,10 @@ export default function classDetails({ navigation, lectureInfo }) {
           <Text style={styles.classTapText}>{showDayTime}</Text>
         </View>
         <View style={styles.classTapframe}>
-          <Text style={styles.classTapHeader}>教室名</Text>
-          <Text style={styles.classTapText}>{balnkClass}</Text>
+          <Text style={styles.classTapHeader}>棟名・教室名</Text>
+          <View style={styles.buildingRoom}>
+            <Text style={styles.classTapText}>{displayedRoomName}</Text>
+          </View>
         </View>
         <View style={styles.ctTuikaContainer}>
           <TouchableOpacity style={styles.ctTuikaBtn} onPress={() => navigation.goBack()}>
@@ -127,6 +149,9 @@ const styles = StyleSheet.create({
     fontSize: 22,
     backgroundColor: '#e6f2f5',
     color: 'black',
+  },
+  buildingRoom: {
+    marginTop: '2%'
   },
   // 追加ボタン関連
   ctTuikaContainer: {

--- a/screens/classTable.js
+++ b/screens/classTable.js
@@ -154,15 +154,27 @@ export default function homeScreenProp() {
   }, [isFocused])
 
   const renderItem = ({ item }) => (
-    <View style={{ flexDirection: 'row', alignItems: 'center', }}>
-      <TouchableHighlight style={{ width: '80%' }} onPress={() => navigation.navigate("Classtap_Screen", item)}>
-        <View style={{ flexDirection: 'row' }}>
+    <View style={{ alignItems: 'center', marginBottom: '2%' }}>
+      <TouchableOpacity style={{ width: '95%', marginBottom: '1%', }} onPress={() => navigation.navigate("Classtap_Screen", item)}>
+        <View style={{ flexDirection: 'row', flex: 1, }}>
           <Text style={styles.otherLectureText}>{item.科目}</Text>
           <Text style={styles.otherLectureText}>{item.担当}</Text>
         </View>
-      </TouchableHighlight>
+      </TouchableOpacity>
     </View>
   );
+
+  const itemSeparator = () => {
+    return (
+      <View
+        style={{
+          height: 1,
+          marginHorizontal: '1%',
+          backgroundColor: "#CED0CE",
+        }}
+      />
+    )
+  }
 
   return (
     <>
@@ -183,13 +195,14 @@ export default function homeScreenProp() {
                 </TableWrapper>
               </Table>
               <View style={styles.otherLectures}>
-                <Text style={styles.otherLectureTitle}>集中講義など</Text>
+                <Text style={styles.otherLectureTitle}>その他の講義</Text>
               </View>
             </View >
           }
           data={flatlistData}
           renderItem={renderItem}
           keyExtractor={item => item.時間割コード}
+          ItemSeparatorComponent={itemSeparator}
           ListFooterComponent={
             < TouchableOpacity style={styles.buttonsita}>
               <Text style={styles.buttomtext}>編集</Text>
@@ -244,9 +257,10 @@ const styles = StyleSheet.create({
   otherLectures: {
     alignItems: 'center',
     marginHorizontal: '2%',
-    marginBottom: '4%',
+    marginVertical: '2%',
   },
   otherLectureText: {
+    flex: 1,
     marginHorizontal: '5%',
     fontSize: 16,
   },

--- a/screens/homeLectureDetail.js
+++ b/screens/homeLectureDetail.js
@@ -3,22 +3,45 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useRoute, useNavigation } from '@react-navigation/native';
 
+// 教室名と棟名が空白の場合の処理
+function changeName(rName, bName,) {
+  if (rName == '' || bName == '') {
+    return '未定またはオンライン講義です';
+  }
+  else if (bName != '' && rName == '') {
+    return bName;
+  }
+  else if (bName == '' && rName != '') {
+    return rName;
+  }
+  else if (bName != '' && rName != '') {
+    return bName + '\n' + rName;
+  }
+};
+
 //授業詳細画面
 export default function lectureDetail() {
   const navigation = useNavigation();
   const route = useRoute();
   const lectureName = route.params.科目;
   const teacher = route.params.担当;
-  let roomName = route.params.教室名;
   const dayTime = route.params.曜日時限;
-  if (roomName == '') {
-    roomName = '未定またはオンライン講義です';
+  let roomName = route.params.教室名;
+  let buildingName = route.params.棟名;
+  let buildName = route.params.棟;
+  let displayedRoomName = '';
+
+  if (buildingName == undefined && buildName != undefined) {
+    displayedRoomName = changeName(roomName, buildName);
   }
+  else if (buildingName != undefined && buildName == undefined) {
+    displayedRoomName = changeName(roomName, buildingName);
+  }
+
   const classDayTime = dayTime.split(',')
   const daytime_1 = classDayTime[0] + 'コマ';
   const daytime_2 = classDayTime[1] + 'コマ';
   const showDaytime = daytime_1 + '・' + daytime_2;
-
 
   return (
     <ScrollView>
@@ -36,8 +59,10 @@ export default function lectureDetail() {
           <Text style={styles.classTapText}>{showDaytime}</Text>
         </View>
         <View style={styles.classTapframe}>
-          <Text style={styles.classTapHeader}>教室名</Text>
-          <Text style={styles.classTapText}>{roomName}</Text>
+          <Text style={styles.classTapHeader}>棟名・教室名</Text>
+          <View style={styles.buildingRoom}>
+          <Text style={styles.classTapText}>{displayedRoomName}</Text>
+          </View>
         </View>
         <View style={styles.ctTuikaContainer}>
           <TouchableOpacity style={styles.ctTuikaBtn} onPress={() => navigation.goBack()}>
@@ -76,6 +101,9 @@ const styles = StyleSheet.create({
     fontSize: 22,
     backgroundColor: '#e6f2f5',
     color: 'black',
+  },
+  buildingRoom: {
+    marginTop: '2%'
   },
   // 追加ボタン関連
   ctTuikaContainer: {


### PR DESCRIPTION
## Done
- 時間割ホーム画面下のデザインの改善
- 講義詳細情報画面での教室・建物情報の追加

## ToDos
- 登録済み講義情報の削除機能
- 他学部の講義検索機能
- 前期・後期の講義情報の切り替え方法の検討と実装
- 講義に対して一意でない時間割コードを使わず、新たにidを割り振ってFlatListへデータを渡す